### PR TITLE
Implement Pedersen commitment counter and related features

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -186,7 +186,8 @@
       "Bash(for url in \"https://publisher.walrus-testnet.walrus.space/v1\" \"https://walrus-testnet-publisher.nodes.guru/v1\" \"https://walrus-testnet-publisher.chainbase.online/v1\" \"https://publisher.walrus-01.tududes.com/v1\")",
       "Bash(do echo \"Testing: $url\")",
       "mcp__serena__list_memories",
-      "Bash(/bin/grep -A 10 \"\\[dependencies\\]\")"
+      "Bash(/bin/grep -A 10 \"\\[dependencies\\]\")",
+      "Bash(/bin/grep -E \"@noble|noble\")"
     ],
     "deny": [],
     "ask": []

--- a/sui/__tests__/utils/pedersen.test.ts
+++ b/sui/__tests__/utils/pedersen.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import {
+  addCommitments,
+  createCommitment,
+  createSerializedCommitment,
+  deserializePoint,
+  generateBlindingFactor,
+  serializeCommitment,
+  verifyCommitment,
+} from "@/utils/pedersen";
+
+describe("Pedersen Commitment", () => {
+  test("should create a commitment with value 0", () => {
+    const commitment = createCommitment(0n);
+    expect(commitment.value).toBe(0n);
+    expect(commitment.blinding).toBeGreaterThan(0n);
+    expect(verifyCommitment(commitment)).toBe(true);
+  });
+
+  test("should create a commitment with small value", () => {
+    const commitment = createCommitment(5n);
+    expect(commitment.value).toBe(5n);
+    expect(verifyCommitment(commitment)).toBe(true);
+  });
+
+  test("should create a commitment with large value", () => {
+    const commitment = createCommitment(123456789n);
+    expect(commitment.value).toBe(123456789n);
+    expect(verifyCommitment(commitment)).toBe(true);
+  });
+
+  test("should generate random blinding factors", () => {
+    const r1 = generateBlindingFactor();
+    const r2 = generateBlindingFactor();
+    expect(r1).not.toBe(r2);
+    expect(r1).toBeGreaterThan(0n);
+    expect(r2).toBeGreaterThan(0n);
+  });
+
+  test("should create commitment with custom blinding", () => {
+    const blinding = 42n;
+    const commitment = createCommitment(10n, blinding);
+    expect(commitment.blinding).toBe(42n);
+    expect(commitment.value).toBe(10n);
+  });
+
+  test("should add commitments homomorphically", () => {
+    const c1 = createCommitment(5n, 100n);
+    const c2 = createCommitment(3n, 200n);
+    const c3 = addCommitments(c1, c2);
+
+    expect(c3.value).toBe(8n);
+    expect(c3.blinding).toBe(300n);
+    expect(verifyCommitment(c3)).toBe(true);
+  });
+
+  test("should serialize and deserialize commitment", () => {
+    const commitment = createCommitment(42n);
+    const bytes = serializeCommitment(commitment);
+
+    expect(bytes.length).toBe(48); // Compressed G1 point
+
+    const point = deserializePoint(bytes);
+    expect(point.equals(commitment.point)).toBe(true);
+  });
+
+  test("should create serialized commitment for Sui", () => {
+    const { commitment, bytes } = createSerializedCommitment(10n);
+
+    expect(Array.isArray(bytes)).toBe(true);
+    expect(bytes.length).toBe(48);
+    expect(bytes.every((b) => typeof b === "number")).toBe(true);
+    expect(verifyCommitment(commitment)).toBe(true);
+  });
+
+  test("should handle value 0 correctly", () => {
+    const { commitment, bytes } = createSerializedCommitment(0n);
+    expect(commitment.value).toBe(0n);
+    expect(bytes.length).toBe(48);
+  });
+});

--- a/sui/mise.toml
+++ b/sui/mise.toml
@@ -379,6 +379,94 @@ echo "  1. mise run gen    # ABI定義の更新"
 echo "  2. mise run dev    # 開発サーバー再起動"
 '''
 
+[tasks."sui:upgrade"]
+description = "Moveコントラクトのアップグレード"
+alias = ["su", "upgrade"]
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+PACKAGE="${1:-counter}"
+NETWORK="${2:-testnet}"
+
+echo "🔄 $PACKAGE を $NETWORK でアップグレード中..."
+echo ""
+
+# Published.toml から upgrade-capability を読み取る
+PUBLISHED_TOML="move/$PACKAGE/Published.toml"
+if [ ! -f "$PUBLISHED_TOML" ]; then
+    echo "❌ エラー: $PUBLISHED_TOML が見つかりません"
+    echo "   パッケージが既にパブリッシュされているか確認してください"
+    exit 1
+fi
+
+UPGRADE_CAP=$(grep "^upgrade-capability" "$PUBLISHED_TOML" | sed 's/.*= "\(.*\)"/\1/')
+if [ -z "$UPGRADE_CAP" ]; then
+    echo "❌ エラー: upgrade-capability が見つかりません"
+    exit 1
+fi
+
+echo "📋 アップグレード情報:"
+echo "   パッケージ: $PACKAGE"
+echo "   ネットワーク: $NETWORK"
+echo "   UpgradeCap: $UPGRADE_CAP"
+echo ""
+
+# ネットワーク切り替え
+mise run sui:env $NETWORK
+
+# ビルド実行
+echo "🔨 パッケージビルド中..."
+cd move/$PACKAGE
+sui move build
+echo ""
+
+# アップグレード実行
+echo "🚀 アップグレード実行中..."
+sui client upgrade \
+    --gas-budget {{vars.gas_budget}} \
+    --upgrade-capability "$UPGRADE_CAP"
+
+echo ""
+echo "✅ アップグレード完了！"
+echo ""
+echo "🔄 次の手順:"
+echo "  1. mise run gen $PACKAGE    # ABI定義の更新"
+echo "  2. mise run dev              # 開発サーバー再起動"
+'''
+
+[tasks."sui:upgrade-info"]
+description = "パッケージのアップグレード情報を表示"
+alias = ["sui-info", "info"]
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+PACKAGE="${1:-counter}"
+
+PUBLISHED_TOML="move/$PACKAGE/Published.toml"
+if [ ! -f "$PUBLISHED_TOML" ]; then
+    echo "❌ エラー: $PUBLISHED_TOML が見つかりません"
+    echo "   パッケージがまだパブリッシュされていません"
+    exit 1
+fi
+
+echo "📋 $PACKAGE のアップグレード情報:"
+echo ""
+cat "$PUBLISHED_TOML"
+echo ""
+
+UPGRADE_CAP=$(grep "^upgrade-capability" "$PUBLISHED_TOML" | sed 's/.*= "\(.*\)"/\1/')
+PUBLISHED_AT=$(grep "^published-at" "$PUBLISHED_TOML" | sed 's/.*= "\(.*\)"/\1/')
+VERSION=$(grep "^version" "$PUBLISHED_TOML" | head -1 | sed 's/.*= \(.*\)/\1/')
+
+echo "🔑 キー情報:"
+echo "   現在のバージョン: $VERSION"
+echo "   Published At: $PUBLISHED_AT"
+echo "   UpgradeCap: $UPGRADE_CAP"
+echo ""
+echo "💡 アップグレードコマンド:"
+echo "   mise run sui:upgrade $PACKAGE [network]"
+'''
+
 [tasks."move:test"]
 description = "Moveコントラクトのテスト実行"
 alias = ["mt", "test:move"]

--- a/sui/move/counter/Move.lock
+++ b/sui/move/counter/Move.lock
@@ -2,12 +2,74 @@
 # This file should be checked in.
 
 [move]
-version = 4
+version = 3
+manifest_digest = "11AD0B205D27724E1113AA3AECA49FD1C680DBCBD99F9463BB326885B43D105B"
+deps_digest = "397E6A9F7A624706DBDFEE056CE88391A15876868FD18A88504DA74EB458D697"
+dependencies = [
+  { id = "Bridge", name = "Bridge" },
+  { id = "MoveStdlib", name = "MoveStdlib" },
+  { id = "Sui", name = "Sui" },
+  { id = "SuiSystem", name = "SuiSystem" },
+  { id = "Walrus", name = "Walrus" },
+]
+
+[[move.package]]
+id = "Bridge"
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "4e8b6eda7d6411d80c62f39ac8a4f028e8d174c4", subdir = "crates/sui-framework/packages/bridge" }
+
+dependencies = [
+  { id = "MoveStdlib", name = "MoveStdlib" },
+  { id = "Sui", name = "Sui" },
+  { id = "SuiSystem", name = "SuiSystem" },
+]
+
+[[move.package]]
+id = "MoveStdlib"
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "4e8b6eda7d6411d80c62f39ac8a4f028e8d174c4", subdir = "crates/sui-framework/packages/move-stdlib" }
+
+[[move.package]]
+id = "Sui"
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "4e8b6eda7d6411d80c62f39ac8a4f028e8d174c4", subdir = "crates/sui-framework/packages/sui-framework" }
+
+dependencies = [
+  { id = "MoveStdlib", name = "MoveStdlib" },
+]
+
+[[move.package]]
+id = "SuiSystem"
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "4e8b6eda7d6411d80c62f39ac8a4f028e8d174c4", subdir = "crates/sui-framework/packages/sui-system" }
+
+dependencies = [
+  { id = "MoveStdlib", name = "MoveStdlib" },
+  { id = "Sui", name = "Sui" },
+]
+
+[[move.package]]
+id = "WAL"
+source = { git = "https://github.com/MystenLabs/walrus.git", rev = "main", subdir = "testnet-contracts/wal" }
+
+dependencies = [
+  { id = "Sui", name = "Sui" },
+]
+
+[[move.package]]
+id = "Walrus"
+source = { git = "https://github.com/MystenLabs/walrus.git", rev = "main", subdir = "testnet-contracts/walrus" }
+
+dependencies = [
+  { id = "Sui", name = "Sui" },
+  { id = "WAL", name = "WAL" },
+]
+
+[move.toolchain-version]
+compiler-version = "1.58.1"
+edition = "2024"
+flavor = "sui"
 
 [pinned.testnet.Counter]
 source = { root = true }
 use_environment = "testnet"
-manifest_digest = "42415ADC2BF7444A6FEF4271D38DFE1F972B49FC63EF61B87842E728700614A1"
+manifest_digest = "67E8AB56BA062EC0EF96702FC3AFF025BD51B82AA5031473608ADA3EE8F42AC4"
 deps = { Walrus = "Walrus", std = "MoveStdlib_1", sui = "Sui_1" }
 
 [pinned.testnet.MoveStdlib]
@@ -35,13 +97,13 @@ manifest_digest = "ED5DEFBBF556EE89312E639A53F21DE24320F9B13C2087D3BFE2989D5B2B5
 deps = { MoveStdlib = "MoveStdlib_1" }
 
 [pinned.testnet.WAL]
-source = { git = "https://github.com/MystenLabs/walrus.git", subdir = "testnet-contracts/wal", rev = "157184c332785bbb82653755fdd169931689f80e" }
+source = { git = "https://github.com/MystenLabs/walrus.git", subdir = "testnet-contracts/wal", rev = "5108b2caabaa7859f3467a7e432ac151f896395c" }
 use_environment = "testnet"
 manifest_digest = "22605453B293891721DA0C3E8596A4D15609F58B98A46EACDD16CEC068BAAE87"
 deps = { Sui = "Sui" }
 
 [pinned.testnet.Walrus]
-source = { git = "https://github.com/MystenLabs/walrus.git", subdir = "testnet-contracts/walrus", rev = "157184c332785bbb82653755fdd169931689f80e" }
+source = { git = "https://github.com/MystenLabs/walrus.git", subdir = "testnet-contracts/walrus", rev = "5108b2caabaa7859f3467a7e432ac151f896395c" }
 use_environment = "testnet"
 manifest_digest = "B8C664B06BC7B99ACEEB08688161E8ADF3C781673E3530340084FD196AEA7802"
 deps = { Sui = "Sui", WAL = "WAL" }

--- a/sui/move/counter/Move.toml
+++ b/sui/move/counter/Move.toml
@@ -1,7 +1,8 @@
 [package]
 name = "Counter"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
+published-at = "0x6aa35f5f737f106c867d45cb02e39c61cbd5359088a929d161363bd34f62fd8a"
 
 [dependencies]
 Walrus = { git = "https://github.com/MystenLabs/walrus.git", subdir = "testnet-contracts/walrus", rev = "main" }

--- a/sui/move/counter/Published.toml
+++ b/sui/move/counter/Published.toml
@@ -4,9 +4,9 @@
 
 [published.testnet]
 chain-id = "4c78adac"
-published-at = "0x04bb1e13575545cd37a837367779cd4df26bdd566bf181b4ac4c358a8fac68d9"
+published-at = "0x6aa35f5f737f106c867d45cb02e39c61cbd5359088a929d161363bd34f62fd8a"
 original-id = "0x04bb1e13575545cd37a837367779cd4df26bdd566bf181b4ac4c358a8fac68d9"
-version = 1
-toolchain-version = "1.58.0"
+version = 3
+toolchain-version = "1.58.1"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0xaf713a497887cb1ea366ce94d6ae3a89eb29e2e85582ab3ba9b433e6c1726abf"

--- a/sui/move/counter/sources/pedersen_counter.move
+++ b/sui/move/counter/sources/pedersen_counter.move
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Pedersen Commitment Counter using homomorphic properties
+///
+/// This counter uses Pedersen commitments to hide the actual counter value
+/// while allowing homomorphic addition through elliptic curve operations.
+///
+/// Commitment: C = value * G + blinding * H
+/// Where G and H are generators on the BLS12-381 G1 curve
+///
+/// Homomorphic property: C1 + C2 = (v1 + v2) * G + (r1 + r2) * H
+/// This allows incrementing the counter without revealing the value.
+module counter::pedersen_counter;
+
+use sui::{bls12381::{Self, Scalar, G1}, group_ops::Element};
+
+// === Structs ===
+
+/// A counter using Pedersen commitment for privacy
+public struct PedersenCounter has key, store {
+    id: UID,
+    /// The commitment to the counter value: C = value * G + blinding * H
+    commitment: Element<G1>,
+}
+
+// === Public Functions ===
+
+/// Create a new Pedersen counter with initial commitment
+/// @param commitment_bytes: Serialized G1 point (48 bytes compressed)
+public fun new(commitment_bytes: vector<u8>, ctx: &mut TxContext): PedersenCounter {
+    PedersenCounter {
+        id: object::new(ctx),
+        commitment: bls12381::g1_from_bytes(&commitment_bytes),
+    }
+}
+
+/// Increment the counter homomorphically by adding a commitment
+/// @param value_commitment_bytes: Serialized G1 point (48 bytes compressed)
+/// C_new = C_old + C_inc
+public fun increment(self: &mut PedersenCounter, value_commitment_bytes: vector<u8>) {
+    let increment_commitment = bls12381::g1_from_bytes(&value_commitment_bytes);
+    self.commitment = bls12381::g1_add(&self.commitment, &increment_commitment);
+}
+
+// === View Functions ===
+
+/// Get the commitment bytes for external verification (48 bytes compressed)
+public fun commitment_bytes(self: &PedersenCounter): vector<u8> {
+    *self.commitment.bytes()
+}
+
+// === Test-only Functions ===
+
+#[test_only]
+/// Get the second generator H by hashing a known string to G1
+fun get_second_generator(): Element<G1> {
+    let seed = b"PEDERSEN_COUNTER_SECOND_GENERATOR";
+    bls12381::hash_to_g1(&seed)
+}
+
+#[test_only]
+/// Create a commitment to a value with a blinding factor (for testing)
+public fun commit(value: u64, blinding: &Element<Scalar>): Element<G1> {
+    let g = bls12381::g1_generator();
+    let h = get_second_generator();
+
+    let value_scalar = bls12381::scalar_from_u64(value);
+    let value_g = bls12381::g1_mul(&value_scalar, &g);
+    let blinding_h = bls12381::g1_mul(blinding, &h);
+
+    bls12381::g1_add(&value_g, &blinding_h)
+}
+
+#[test_only]
+/// Verify that a commitment opens to a specific value
+public fun verify_opening(commitment: &Element<G1>, value: u64, blinding: &Element<Scalar>): bool {
+    let expected = commit(value, blinding);
+    sui::group_ops::equal(commitment, &expected)
+}
+
+#[test_only]
+/// Verify that a counter opens to a specific value
+public fun verify_counter_value(
+    self: &PedersenCounter,
+    value: u64,
+    blinding: &Element<Scalar>,
+): bool {
+    verify_opening(&self.commitment, value, blinding)
+}
+
+#[test_only]
+public fun destroy_for_testing(counter: PedersenCounter) {
+    let PedersenCounter { id, commitment: _ } = counter;
+    object::delete(id);
+}

--- a/sui/move/counter/sources/pedersen_counter.move
+++ b/sui/move/counter/sources/pedersen_counter.move
@@ -1,6 +1,3 @@
-// Copyright (c) Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 /// Pedersen Commitment Counter using homomorphic properties
 ///
 /// This counter uses Pedersen commitments to hide the actual counter value
@@ -13,7 +10,7 @@
 /// This allows incrementing the counter without revealing the value.
 module counter::pedersen_counter;
 
-use sui::{bls12381::{Self, Scalar, G1}, group_ops::Element};
+use sui::{bls12381::{Self, G1, Scalar}, group_ops::Element};
 
 // === Structs ===
 

--- a/sui/move/counter/tests/pedersen_counter.test.move
+++ b/sui/move/counter/tests/pedersen_counter.test.move
@@ -1,0 +1,133 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[test_only]
+module counter::pedersen_counter_tests;
+
+use counter::pedersen_counter;
+use sui::{bls12381, test_scenario};
+
+#[test]
+fun test_create_and_verify_commitment() {
+    let scenario = test_scenario::begin(@0x1);
+
+    // Create a commitment to value 5 with random blinding
+    let blinding = bls12381::scalar_from_u64(42);
+    let commitment = pedersen_counter::commit(5, &blinding);
+
+    // Verify the commitment opens correctly
+    assert!(pedersen_counter::verify_opening(&commitment, 5, &blinding), 0);
+
+    // Verify it fails with wrong value
+    assert!(!pedersen_counter::verify_opening(&commitment, 6, &blinding), 1);
+
+    // Verify it fails with wrong blinding
+    let wrong_blinding = bls12381::scalar_from_u64(99);
+    assert!(!pedersen_counter::verify_opening(&commitment, 5, &wrong_blinding), 2);
+
+    test_scenario::end(scenario);
+}
+
+#[test]
+fun test_counter_creation_and_verification() {
+    let mut scenario = test_scenario::begin(@0x1);
+    let ctx = test_scenario::ctx(&mut scenario);
+
+    // Create a counter with initial value 10
+    let blinding = bls12381::scalar_from_u64(123);
+    let commitment = pedersen_counter::commit(10, &blinding);
+    let commitment_bytes = *commitment.bytes();
+    let counter = pedersen_counter::new(commitment_bytes, ctx);
+
+    // Verify the counter value
+    assert!(pedersen_counter::verify_counter_value(&counter, 10, &blinding), 0);
+
+    pedersen_counter::destroy_for_testing(counter);
+    test_scenario::end(scenario);
+}
+
+#[test]
+fun test_homomorphic_increment() {
+    let mut scenario = test_scenario::begin(@0x1);
+    let ctx = test_scenario::ctx(&mut scenario);
+
+    // Create counter with value 5
+    let blinding1 = bls12381::scalar_from_u64(100);
+    let commitment1 = pedersen_counter::commit(5, &blinding1);
+    let commitment1_bytes = *commitment1.bytes();
+    let mut counter = pedersen_counter::new(commitment1_bytes, ctx);
+
+    // Create increment commitment for value 3
+    let blinding2 = bls12381::scalar_from_u64(200);
+    let increment_commitment = pedersen_counter::commit(3, &blinding2);
+    let increment_bytes = *increment_commitment.bytes();
+
+    // Increment homomorphically
+    counter.increment(increment_bytes);
+
+    // The new value should be 8 with combined blinding (100 + 200 = 300)
+    let combined_blinding = bls12381::scalar_add(&blinding1, &blinding2);
+    assert!(pedersen_counter::verify_counter_value(&counter, 8, &combined_blinding), 0);
+
+    pedersen_counter::destroy_for_testing(counter);
+    test_scenario::end(scenario);
+}
+
+#[test]
+fun test_multiple_increments() {
+    let mut scenario = test_scenario::begin(@0x1);
+    let ctx = test_scenario::ctx(&mut scenario);
+
+    // Start with value 0
+    let mut total_blinding = bls12381::scalar_from_u64(0);
+    let commitment = pedersen_counter::commit(0, &total_blinding);
+    let commitment_bytes = *commitment.bytes();
+    let mut counter = pedersen_counter::new(commitment_bytes, ctx);
+
+    // Increment 5 times
+    let mut i = 0;
+    while (i < 5) {
+        let increment_blinding = bls12381::scalar_from_u64(i + 1);
+        let increment_commitment = pedersen_counter::commit(1, &increment_blinding);
+        let increment_bytes = *increment_commitment.bytes();
+        counter.increment(increment_bytes);
+        total_blinding = bls12381::scalar_add(&total_blinding, &increment_blinding);
+        i = i + 1;
+    };
+
+    // Final value should be 5 with accumulated blinding (0+1+2+3+4+5 = 15)
+    assert!(pedersen_counter::verify_counter_value(&counter, 5, &total_blinding), 0);
+
+    pedersen_counter::destroy_for_testing(counter);
+    test_scenario::end(scenario);
+}
+
+#[test]
+fun test_commitment_privacy() {
+    let mut scenario = test_scenario::begin(@0x1);
+    let ctx = test_scenario::ctx(&mut scenario);
+
+    // Create two counters with same value but different blinding factors
+    let blinding1 = bls12381::scalar_from_u64(111);
+    let commitment1 = pedersen_counter::commit(42, &blinding1);
+    let bytes1 = *commitment1.bytes();
+    let counter1 = pedersen_counter::new(bytes1, ctx);
+
+    let blinding2 = bls12381::scalar_from_u64(222);
+    let commitment2 = pedersen_counter::commit(42, &blinding2);
+    let bytes2 = *commitment2.bytes();
+    let counter2 = pedersen_counter::new(bytes2, ctx);
+
+    // The commitments should be different (privacy property)
+    let counter_bytes1 = counter1.commitment_bytes();
+    let counter_bytes2 = counter2.commitment_bytes();
+    assert!(counter_bytes1 != counter_bytes2, 0);
+
+    // But both should open to the same value with their respective blinding factors
+    assert!(pedersen_counter::verify_counter_value(&counter1, 42, &blinding1), 1);
+    assert!(pedersen_counter::verify_counter_value(&counter2, 42, &blinding2), 2);
+
+    pedersen_counter::destroy_for_testing(counter1);
+    pedersen_counter::destroy_for_testing(counter2);
+    test_scenario::end(scenario);
+}

--- a/sui/src/app/page.tsx
+++ b/sui/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCurrentAccount } from "@mysten/dapp-kit";
-import { ArrowRight, Database, Lock, Package } from "lucide-react";
+import { ArrowRight, Database, Lock, Package, Shield } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -92,6 +92,31 @@ export default function HomePage() {
                     <Button asChild className="w-full" variant="outline">
                       <Link href="/walrus-counter">
                         Try Walrus Counter
+                        <ArrowRight className="ml-2 h-4 w-4" />
+                      </Link>
+                    </Button>
+                  </CardContent>
+                </Card>
+
+                <Card className="transition-shadow hover:shadow-lg">
+                  <CardHeader>
+                    <div className="mb-2 flex items-center gap-3">
+                      <Shield className="h-8 w-8 text-primary" />
+                      <CardTitle>Pedersen Counter</CardTitle>
+                    </div>
+                    <CardDescription>
+                      Privacy-preserving counter using cryptographic commitments
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="mb-4 space-y-2 text-muted-foreground text-sm">
+                      <li>• Hidden values (commitments)</li>
+                      <li>• Homomorphic operations</li>
+                      <li>• Cryptographic privacy</li>
+                    </ul>
+                    <Button asChild className="w-full" variant="outline">
+                      <Link href="/pedersen-counter">
+                        Try Pedersen Counter
                         <ArrowRight className="ml-2 h-4 w-4" />
                       </Link>
                     </Button>

--- a/sui/src/app/pedersen-counter/[objectId]/page.tsx
+++ b/sui/src/app/pedersen-counter/[objectId]/page.tsx
@@ -1,0 +1,15 @@
+import { PedersenCounter } from "@/components/PedersenCounter";
+
+export default async function PedersenCounterObject({
+  params,
+}: {
+  params: Promise<{ objectId: string }>;
+}) {
+  const { objectId } = await params;
+
+  if (!objectId) {
+    return <div>Invalid counter ID</div>;
+  }
+
+  return <PedersenCounter id={objectId} />;
+}

--- a/sui/src/app/pedersen-counter/page.tsx
+++ b/sui/src/app/pedersen-counter/page.tsx
@@ -1,0 +1,79 @@
+import { PedersenCounterCreate } from "@/components/PedersenCounterCreate";
+import { PedersenCounterList } from "@/components/PedersenCounterList";
+
+export default function PedersenCounterPage() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="space-y-8">
+        {/* Header */}
+        <div className="space-y-2 text-center">
+          <h1 className="font-bold text-3xl">Pedersen Counters</h1>
+          <p className="text-muted-foreground">
+            Privacy-preserving counters using Pedersen commitments and homomorphic operations
+          </p>
+        </div>
+
+        <PedersenCounterCreate />
+
+        <div className="space-y-4">
+          <h2 className="font-semibold text-2xl">Your Pedersen Counters</h2>
+          <PedersenCounterList />
+        </div>
+
+        {/* Educational Info */}
+        <div className="mx-auto max-w-3xl rounded-lg border bg-card p-6">
+          <h3 className="mb-4 font-semibold text-xl">How Pedersen Counters Work</h3>
+          <div className="space-y-4 text-muted-foreground text-sm">
+            <div>
+              <p className="mb-2 font-medium text-foreground">🔐 Cryptographic Commitment</p>
+              <p>
+                Values are hidden using Pedersen commitments:{" "}
+                <code>C = value × G + blinding × H</code>
+              </p>
+              <p className="mt-1">
+                where G and H are generators on the BLS12-381 G1 curve. Only the 48-byte commitment
+                is stored on-chain.
+              </p>
+            </div>
+
+            <div>
+              <p className="mb-2 font-medium text-foreground">➕ Homomorphic Addition</p>
+              <p>
+                Counters can be incremented without revealing values:
+                <code className="ml-1">C₁ + C₂ = (v₁ + v₂) × G + (r₁ + r₂) × H</code>
+              </p>
+              <p className="mt-1">
+                This allows mathematical operations on encrypted data while preserving privacy.
+              </p>
+            </div>
+
+            <div>
+              <p className="mb-2 font-medium text-foreground">🛡️ Security Properties</p>
+              <ul className="ml-4 list-disc space-y-1">
+                <li>
+                  <strong>Hiding:</strong> Commitment reveals no information about the value
+                </li>
+                <li>
+                  <strong>Binding:</strong> Cannot change the committed value after creation
+                </li>
+                <li>
+                  <strong>Homomorphic:</strong> Supports addition without decryption
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <p className="mb-2 font-medium text-foreground">💡 Use Cases</p>
+              <ul className="ml-4 list-disc space-y-1">
+                <li>Private voting systems with verifiable tallies</li>
+                <li>Confidential transaction amounts (like Mimblewimble)</li>
+                <li>Privacy-preserving auctions and sealed-bid protocols</li>
+                <li>Anonymous reputation systems</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/sui/src/components/AppBar.tsx
+++ b/sui/src/components/AppBar.tsx
@@ -41,6 +41,12 @@ export function AppBar() {
             >
               Walrus Counter
             </Link>
+            <Link
+              href="/pedersen-counter"
+              className="font-medium text-sm transition-colors hover:text-primary"
+            >
+              Pedersen Counter
+            </Link>
           </nav>
         </div>
         <div className="flex items-center gap-2">

--- a/sui/src/components/PedersenCounter.tsx
+++ b/sui/src/components/PedersenCounter.tsx
@@ -4,16 +4,18 @@ import { useSuiClient } from "@mysten/dapp-kit";
 import { formatAddress } from "@mysten/sui/utils";
 import { useQuery } from "@tanstack/react-query";
 import consola from "consola";
-import { Copy, ExternalLink, Loader2, Shield } from "lucide-react";
+import { Copy, ExternalLink, Eye, Loader2, Shield } from "lucide-react";
 import { ResultAsync } from "neverthrow";
 import { useId, useState } from "react";
 import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { usePedersenCounter } from "@/hooks/usePedersenCounter";
+import { type OpeningResult, usePedersenOpening } from "@/hooks/usePedersenOpening";
 
 interface PedersenCounterProps {
   id: string;
@@ -22,7 +24,9 @@ interface PedersenCounterProps {
 export function PedersenCounter({ id }: PedersenCounterProps) {
   const suiClient = useSuiClient();
   const pedersenCounter = usePedersenCounter();
+  const opening = usePedersenOpening();
   const [incrementValue, setIncrementValue] = useState("1");
+  const [openResult, setOpenResult] = useState<OpeningResult | null>(null);
   const inputId = useId();
 
   // Fetch counter data
@@ -95,7 +99,26 @@ export function PedersenCounter({ id }: PedersenCounterProps) {
       return;
     }
 
+    // Clear previous opening result since commitment changed
+    setOpenResult(null);
     refetch();
+  };
+
+  const handleOpen = async () => {
+    if (!data) return;
+
+    const result = await opening.open(id, data.commitmentBytes);
+    setOpenResult(result);
+
+    if (result.success) {
+      toast.success("Commitment opened successfully!", {
+        description: `Revealed value: ${result.value}`,
+      });
+    } else {
+      toast.error("Failed to open commitment", {
+        description: result.error,
+      });
+    }
   };
 
   const copyToClipboard = (text: string) => {
@@ -268,6 +291,107 @@ export function PedersenCounter({ id }: PedersenCounterProps) {
                 <li>Result: C_new = C_old + C_increment</li>
                 <li>The actual value remains hidden throughout</li>
               </ol>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Opening (Reveal Value) */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Eye className="h-5 w-5" />
+              Open Commitment (Reveal Value)
+            </CardTitle>
+            <CardDescription>
+              Reveal the actual counter value using secrets stored in your browser. This verifies
+              that you created this counter.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {opening.checkHasSecrets(id) ? (
+              <>
+                <Button
+                  size="lg"
+                  variant="secondary"
+                  onClick={handleOpen}
+                  disabled={opening.isOpening}
+                  className="w-full"
+                >
+                  {opening.isOpening ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Opening...
+                    </>
+                  ) : (
+                    <>
+                      <Eye className="mr-2 h-4 w-4" />
+                      Open Commitment
+                    </>
+                  )}
+                </Button>
+
+                {openResult?.success && openResult.value !== undefined && (
+                  <Alert className="border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950">
+                    <AlertTitle className="text-green-900 dark:text-green-100">
+                      ✅ Commitment Opened Successfully
+                    </AlertTitle>
+                    <AlertDescription className="mt-2">
+                      <div className="space-y-2">
+                        <p className="text-muted-foreground text-sm">Revealed counter value:</p>
+                        <div className="rounded-lg border bg-background p-4">
+                          <p className="font-bold text-3xl text-green-600 dark:text-green-400">
+                            {openResult.value.toString()}
+                          </p>
+                        </div>
+                        <p className="text-muted-foreground text-xs">
+                          This value was cryptographically verified against the on-chain commitment.
+                        </p>
+                      </div>
+                    </AlertDescription>
+                  </Alert>
+                )}
+
+                {openResult && !openResult.success && (
+                  <Alert variant="destructive">
+                    <AlertTitle>❌ Opening Failed</AlertTitle>
+                    <AlertDescription className="text-sm">{openResult.error}</AlertDescription>
+                  </Alert>
+                )}
+
+                <div className="rounded-md border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950">
+                  <p className="font-medium text-sm">ℹ️ How Opening Works</p>
+                  <ol className="mt-2 ml-4 list-decimal space-y-1 text-muted-foreground text-xs">
+                    <li>Retrieve stored value and blinding factor from localStorage</li>
+                    <li>Recreate the commitment: C = value × G + blinding × H</li>
+                    <li>Compare with on-chain commitment byte-by-byte</li>
+                    <li>If they match, the value is cryptographically proven correct</li>
+                  </ol>
+                </div>
+              </>
+            ) : (
+              <Alert variant="destructive">
+                <AlertTitle>🔒 No Secrets Available</AlertTitle>
+                <AlertDescription className="space-y-2 text-sm">
+                  <p>No secrets found for this counter in localStorage. This can happen if:</p>
+                  <ul className="ml-4 list-disc space-y-1">
+                    <li>This counter was created on a different device or browser</li>
+                    <li>Your browser&apos;s localStorage was cleared</li>
+                    <li>You&apos;re viewing someone else&apos;s counter</li>
+                  </ul>
+                  <p className="mt-2 font-semibold">
+                    💡 Only the creator can reveal the value of a Pedersen counter.
+                  </p>
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950">
+              <p className="font-medium text-sm">⚠️ Security Notice</p>
+              <p className="mt-1 text-muted-foreground text-xs">
+                Secrets are stored in plaintext in your browser&apos;s localStorage. They are not
+                encrypted and will be permanently lost if localStorage is cleared. Consider
+                exporting your secrets for backup if you need long-term access.
+              </p>
             </div>
           </CardContent>
         </Card>

--- a/sui/src/components/PedersenCounter.tsx
+++ b/sui/src/components/PedersenCounter.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useSuiClient } from "@mysten/dapp-kit";
+import { formatAddress } from "@mysten/sui/utils";
+import { useQuery } from "@tanstack/react-query";
+import consola from "consola";
+import { Copy, ExternalLink, Loader2, Shield } from "lucide-react";
+import { ResultAsync } from "neverthrow";
+import { useId, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { usePedersenCounter } from "@/hooks/usePedersenCounter";
+
+interface PedersenCounterProps {
+  id: string;
+}
+
+export function PedersenCounter({ id }: PedersenCounterProps) {
+  const suiClient = useSuiClient();
+  const pedersenCounter = usePedersenCounter();
+  const [incrementValue, setIncrementValue] = useState("1");
+  const inputId = useId();
+
+  // Fetch counter data
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ["pedersen-counter", id],
+    queryFn: async () => {
+      consola.log("[PedersenCounter] Fetching object:", id);
+      const obj = await suiClient.getObject({
+        id,
+        options: { showContent: true, showType: true },
+      });
+
+      consola.log("[PedersenCounter] Object response:", obj);
+
+      if (!obj.data?.content || obj.data.content.dataType !== "moveObject") {
+        consola.warn("[PedersenCounter] Invalid object data:", obj.data);
+        return null;
+      }
+
+      consola.log("[PedersenCounter] Content:", obj.data.content);
+      consola.log("[PedersenCounter] Type:", obj.data.type);
+
+      const fields = obj.data.content.fields as Record<string, unknown>;
+      consola.log("[PedersenCounter] Fields:", fields);
+
+      const commitment = fields.commitment as Record<string, unknown>;
+      consola.log("[PedersenCounter] Commitment:", commitment);
+
+      if (!commitment || typeof commitment !== "object" || !("fields" in commitment)) {
+        consola.warn("[PedersenCounter] Invalid commitment structure - no fields");
+        return null;
+      }
+
+      const commitmentFields = commitment.fields as Record<string, unknown>;
+      consola.log("[PedersenCounter] Commitment fields:", commitmentFields);
+
+      if (!commitmentFields || !("bytes" in commitmentFields)) {
+        consola.warn("[PedersenCounter] Invalid commitment fields - no bytes");
+        return null;
+      }
+
+      const bytes = commitmentFields.bytes as number[];
+
+      return {
+        id,
+        commitmentBytes: bytes,
+        version: obj.data.version,
+      };
+    },
+    enabled: !!id,
+  });
+
+  const isIncrementing = pedersenCounter.isPending.increment;
+
+  const handleIncrement = async () => {
+    const value = BigInt(incrementValue);
+    if (value <= 0n) {
+      toast.error("Increment value must be positive");
+      return;
+    }
+
+    const result = await ResultAsync.fromPromise(
+      pedersenCounter.increment({ counterId: id, incrementValue: value }),
+      (err) => new Error(err instanceof Error ? err.message : String(err)),
+    );
+
+    if (result.isErr()) {
+      consola.error("Failed to increment:", result.error);
+      toast.error("Failed to increment counter");
+      return;
+    }
+
+    refetch();
+  };
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+    toast.success("Copied to clipboard");
+  };
+
+  const formatCommitment = (bytes: number[]): string => {
+    return bytes.map((b) => b.toString(16).padStart(2, "0")).join("");
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[400px] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex justify-center pt-6">
+        <Card className="w-full max-w-md">
+          <CardContent className="pt-6">
+            <div className="text-center text-red-600">
+              <p className="font-semibold">Error Loading Counter</p>
+              <p className="mt-2 text-sm">{(error as Error).message}</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex justify-center pt-6">
+        <Card className="w-full max-w-md">
+          <CardContent className="pt-6">
+            <div className="text-center text-amber-600">
+              <p className="font-semibold">Object Data Unavailable</p>
+              <p className="mt-2 text-sm">
+                This object exists on the network but cannot be read with the current package
+                configuration.
+              </p>
+              <p className="mt-4 text-muted-foreground text-xs">Counter ID: {formatAddress(id)}</p>
+              <div className="mt-4">
+                <a
+                  href={`https://testnet.suivision.xyz/object/${id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-center gap-1 text-blue-500 text-sm hover:text-blue-700"
+                >
+                  View on SuiVision Explorer <ExternalLink className="h-4 w-4" />
+                </a>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-2xl px-4 py-8">
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <h1 className="flex items-center gap-2 font-bold text-2xl">
+              <Shield className="h-6 w-6" />
+              Pedersen Counter
+            </h1>
+            <div className="flex items-center gap-2 text-muted-foreground text-sm">
+              <code className="font-mono">{formatAddress(id)}</code>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 w-6 p-0"
+                onClick={() => copyToClipboard(id)}
+              >
+                <Copy className="h-3 w-3" />
+              </Button>
+            </div>
+          </div>
+          <Badge variant="secondary">Version {data.version}</Badge>
+        </div>
+
+        {/* Commitment Display */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <span>Commitment (Hidden Value)</span>
+              <Badge variant="outline" className="font-mono">
+                🔐 Private
+              </Badge>
+            </CardTitle>
+            <CardDescription>
+              The actual counter value is hidden using a Pedersen commitment. Only the commitment
+              (48 bytes) is stored on-chain.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>Commitment Bytes (BLS12-381 G1 Point)</Label>
+              <div className="rounded-lg border bg-muted p-3">
+                <code className="block break-all font-mono text-xs">
+                  {formatCommitment(data.commitmentBytes)}
+                </code>
+              </div>
+              <p className="text-muted-foreground text-xs">
+                48 bytes (compressed G1 point on BLS12-381 curve)
+              </p>
+            </div>
+
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-950">
+              <p className="font-medium text-sm">⚠️ Privacy Note</p>
+              <p className="mt-1 text-muted-foreground text-xs">
+                The actual value is cryptographically hidden. Only you know the true count, as the
+                blinding factor was generated locally in your browser.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Increment Controls */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Homomorphic Increment</CardTitle>
+            <CardDescription>
+              Add to the counter without revealing the value. The operation happens on encrypted
+              data.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor={inputId}>Increment Amount</Label>
+              <Input
+                id={inputId}
+                type="number"
+                min="1"
+                value={incrementValue}
+                onChange={(e) => setIncrementValue(e.target.value)}
+                placeholder="Enter amount to increment"
+                disabled={isIncrementing}
+              />
+            </div>
+
+            <Button
+              size="lg"
+              onClick={handleIncrement}
+              disabled={isIncrementing}
+              className="w-full"
+            >
+              {isIncrementing ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Incrementing...
+                </>
+              ) : (
+                `Increment by ${incrementValue}`
+              )}
+            </Button>
+
+            <div className="space-y-2 rounded-md bg-muted p-3 text-xs">
+              <p className="font-semibold">How it works:</p>
+              <ol className="ml-4 list-decimal space-y-1">
+                <li>A new commitment is created for the increment value</li>
+                <li>The commitments are added homomorphically on-chain</li>
+                <li>Result: C_new = C_old + C_increment</li>
+                <li>The actual value remains hidden throughout</li>
+              </ol>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Explorer Link */}
+        <div className="flex justify-center">
+          <a
+            href={`https://testnet.suivision.xyz/object/${id}?tab=Overview&network=testnet`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-blue-500 text-sm hover:text-blue-700"
+          >
+            View on SuiVision Explorer
+            <ExternalLink className="h-4 w-4" />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/sui/src/components/PedersenCounterCreate.tsx
+++ b/sui/src/components/PedersenCounterCreate.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useId, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { usePedersenCounter } from "@/hooks/usePedersenCounter";
+
+export function PedersenCounterCreate({ onSuccess }: { onSuccess?: () => void }) {
+  const router = useRouter();
+  const pedersenCounter = usePedersenCounter();
+  const [initialValue, setInitialValue] = useState("0");
+  const inputId = useId();
+
+  const isCreating = pedersenCounter.isPending.create;
+
+  function handleCreate() {
+    const value = BigInt(initialValue);
+    pedersenCounter.create({ initialValue: value }).then((counterId) => {
+      onSuccess?.();
+      router.push(`/pedersen-counter/${counterId}`);
+    });
+  }
+
+  return (
+    <div className="flex justify-center">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Create Pedersen Counter</CardTitle>
+          <CardDescription>
+            Create a counter using Pedersen commitments to hide the actual value while allowing
+            homomorphic operations
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor={inputId}>Initial Value (Committed)</Label>
+            <Input
+              id={inputId}
+              type="number"
+              min="0"
+              value={initialValue}
+              onChange={(e) => setInitialValue(e.target.value)}
+              placeholder="Enter initial value"
+              disabled={isCreating}
+            />
+            <p className="text-muted-foreground text-xs">
+              This value will be hidden using a Pedersen commitment. Only you will know the actual
+              value.
+            </p>
+          </div>
+
+          <Button size="lg" onClick={handleCreate} disabled={isCreating} className="w-full">
+            {isCreating ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Creating Commitment...
+              </>
+            ) : (
+              "Create Pedersen Counter"
+            )}
+          </Button>
+
+          <div className="space-y-2 rounded-md bg-muted p-3 text-xs">
+            <p className="font-semibold">🔐 Privacy Features:</p>
+            <ul className="ml-4 list-disc space-y-1">
+              <li>Value is hidden using cryptographic commitment</li>
+              <li>Random blinding factor ensures security</li>
+              <li>Homomorphic increments preserve privacy</li>
+              <li>Only commitment (48 bytes) is stored on-chain</li>
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/sui/src/components/PedersenCounterList.tsx
+++ b/sui/src/components/PedersenCounterList.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { formatAddress } from "@mysten/sui/utils";
+import { Copy, ExternalLink, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { usePedersenCounterList } from "@/hooks/queries/usePedersenCounterList";
+
+export function PedersenCounterList() {
+  const router = useRouter();
+
+  const { data: pedersenCounters = [], isLoading } = usePedersenCounterList();
+
+  function copyToClipboard(text: string) {
+    navigator.clipboard.writeText(text);
+    toast.success("Copied to clipboard");
+  }
+
+  function formatCommitment(bytes: number[]): string {
+    // Show first 8 bytes in hex
+    return bytes
+      .slice(0, 8)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (pedersenCounters.length === 0) {
+    return (
+      <Card className="w-full">
+        <CardContent className="flex flex-col items-center justify-center py-12 text-center">
+          <p className="mb-2 font-medium text-lg text-muted-foreground">
+            No Pedersen counters found
+          </p>
+          <p className="text-muted-foreground text-sm">
+            Create your first Pedersen counter to get started
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="font-semibold text-xl">Your Pedersen Counters ({pedersenCounters.length})</h2>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {pedersenCounters.map((counter) => (
+          <Card key={counter.id} className="transition-shadow hover:shadow-md">
+            <CardHeader className="pb-3">
+              <div className="flex items-start justify-between">
+                <div className="min-w-0 flex-1 space-y-1">
+                  <CardTitle className="text-lg">Pedersen Counter</CardTitle>
+                  <div className="flex items-center space-x-2">
+                    <code className="font-mono text-muted-foreground text-xs">
+                      {formatAddress(counter.id)}
+                    </code>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-4 w-4 p-0"
+                      onClick={() => copyToClipboard(counter.id)}
+                    >
+                      <Copy className="h-3 w-3" />
+                    </Button>
+                  </div>
+                </div>
+                <Badge variant="secondary" className="font-mono text-xs">
+                  🔐 Hidden
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-3 pt-0">
+              <div className="space-y-1">
+                <div className="text-muted-foreground text-xs">Commitment (48 bytes):</div>
+                <code className="block break-all rounded bg-muted p-2 font-mono text-xs">
+                  {formatCommitment(counter.commitmentBytes)}...
+                </code>
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div className="text-muted-foreground text-sm">Version: {counter.version}</div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => router.push(`/pedersen-counter/${counter.id}`)}
+                  className="flex items-center space-x-1"
+                >
+                  <span>Open</span>
+                  <ExternalLink className="h-3 w-3" />
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/sui/src/generated/counter/pedersen_counter.ts
+++ b/sui/src/generated/counter/pedersen_counter.ts
@@ -1,0 +1,109 @@
+/**************************************************************
+ * THIS FILE IS GENERATED AND SHOULD NOT BE MANUALLY MODIFIED *
+ **************************************************************/
+
+/**
+ * Pedersen Commitment Counter using homomorphic properties
+ *
+ * This counter uses Pedersen commitments to hide the actual counter value while
+ * allowing homomorphic addition through elliptic curve operations.
+ *
+ * Commitment: C = value _ G + blinding _ H Where G and H are generators on the
+ * BLS12-381 G1 curve
+ *
+ * Homomorphic property: C1 + C2 = (v1 + v2) _ G + (r1 + r2) _ H This allows
+ * incrementing the counter without revealing the value.
+ */
+
+import { type Transaction } from "@mysten/sui/transactions";
+import { MoveStruct, normalizeMoveArguments, type RawTransactionArgument } from "../utils/index";
+import * as group_ops from "./deps/sui/group_ops";
+import * as object from "./deps/sui/object";
+
+const $moduleName = "@local-pkg/counter::pedersen_counter";
+export const PedersenCounter = new MoveStruct({
+  name: `${$moduleName}::PedersenCounter`,
+  fields: {
+    id: object.UID,
+    /** The commitment to the counter value: C = value _ G + blinding _ H */
+    commitment: group_ops.Element,
+  },
+});
+export interface NewArguments {
+  commitmentBytes: RawTransactionArgument<number[]>;
+}
+export interface NewOptions {
+  package?: string;
+  arguments: NewArguments | [commitmentBytes: RawTransactionArgument<number[]>];
+}
+/**
+ * Create a new Pedersen counter with initial commitment @param commitment_bytes:
+ * Serialized G1 point (48 bytes compressed)
+ */
+export function _new(options: NewOptions) {
+  const packageAddress = options.package ?? "@local-pkg/counter";
+  const argumentsTypes = ["vector<u8>"] satisfies string[];
+  const parameterNames = ["commitmentBytes"];
+  return (tx: Transaction) =>
+    tx.moveCall({
+      package: packageAddress,
+      module: "pedersen_counter",
+      function: "new",
+      arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+    });
+}
+export interface IncrementArguments {
+  self: RawTransactionArgument<string>;
+  valueCommitmentBytes: RawTransactionArgument<number[]>;
+}
+export interface IncrementOptions {
+  package?: string;
+  arguments:
+    | IncrementArguments
+    | [
+        self: RawTransactionArgument<string>,
+        valueCommitmentBytes: RawTransactionArgument<number[]>,
+      ];
+}
+/**
+ * Increment the counter homomorphically by adding a commitment @param
+ * value_commitment_bytes: Serialized G1 point (48 bytes compressed) C_new =
+ * C_old + C_inc
+ */
+export function increment(options: IncrementOptions) {
+  const packageAddress = options.package ?? "@local-pkg/counter";
+  const argumentsTypes = [
+    `${packageAddress}::pedersen_counter::PedersenCounter`,
+    "vector<u8>",
+  ] satisfies string[];
+  const parameterNames = ["self", "valueCommitmentBytes"];
+  return (tx: Transaction) =>
+    tx.moveCall({
+      package: packageAddress,
+      module: "pedersen_counter",
+      function: "increment",
+      arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+    });
+}
+export interface CommitmentBytesArguments {
+  self: RawTransactionArgument<string>;
+}
+export interface CommitmentBytesOptions {
+  package?: string;
+  arguments: CommitmentBytesArguments | [self: RawTransactionArgument<string>];
+}
+/** Get the commitment bytes for external verification (48 bytes compressed) */
+export function commitmentBytes(options: CommitmentBytesOptions) {
+  const packageAddress = options.package ?? "@local-pkg/counter";
+  const argumentsTypes = [
+    `${packageAddress}::pedersen_counter::PedersenCounter`,
+  ] satisfies string[];
+  const parameterNames = ["self"];
+  return (tx: Transaction) =>
+    tx.moveCall({
+      package: packageAddress,
+      module: "pedersen_counter",
+      function: "commitment_bytes",
+      arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+    });
+}

--- a/sui/src/generated/counter/walrus_counter.ts
+++ b/sui/src/generated/counter/walrus_counter.ts
@@ -25,9 +25,7 @@ export interface NewOptions {
 }
 export function _new(options: NewOptions) {
   const packageAddress = options.package ?? "@local-pkg/counter";
-  const argumentsTypes = [
-    "0xd84704c17fc870b8764832c535aa6b11f21a95cd6f5bb38a9b07d2cf42220c66::blob::Blob",
-  ] satisfies string[];
+  const argumentsTypes = [`${packageAddress}::blob::Blob`] satisfies string[];
   const parameterNames = ["blob"];
   return (tx: Transaction) =>
     tx.moveCall({
@@ -51,7 +49,7 @@ export function replace(options: ReplaceOptions) {
   const packageAddress = options.package ?? "@local-pkg/counter";
   const argumentsTypes = [
     `${packageAddress}::walrus_counter::WalrusCounter`,
-    "0xd84704c17fc870b8764832c535aa6b11f21a95cd6f5bb38a9b07d2cf42220c66::blob::Blob",
+    `${packageAddress}::blob::Blob`,
   ] satisfies string[];
   const parameterNames = ["self", "newBlob"];
   return (tx: Transaction) =>

--- a/sui/src/generated/walrus/shared_blob.ts
+++ b/sui/src/generated/walrus/shared_blob.ts
@@ -52,7 +52,7 @@ export function newFunded(options: NewFundedOptions) {
   const packageAddress = options.package ?? "Walrus";
   const argumentsTypes = [
     `${packageAddress}::blob::Blob`,
-    "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a::wal::WAL>",
+    `0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<${packageAddress}::wal::WAL>`,
   ] satisfies string[];
   const parameterNames = ["blob", "funds"];
   return (tx: Transaction) =>
@@ -78,7 +78,7 @@ export function fund(options: FundOptions) {
   const packageAddress = options.package ?? "Walrus";
   const argumentsTypes = [
     `${packageAddress}::shared_blob::SharedBlob`,
-    "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a::wal::WAL>",
+    `0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<${packageAddress}::wal::WAL>`,
   ] satisfies string[];
   const parameterNames = ["self", "addedFunds"];
   return (tx: Transaction) =>

--- a/sui/src/generated/walrus/staking.ts
+++ b/sui/src/generated/walrus/staking.ts
@@ -674,7 +674,7 @@ export function stakeWithPool(options: StakeWithPoolOptions) {
   const packageAddress = options.package ?? "Walrus";
   const argumentsTypes = [
     `${packageAddress}::staking::Staking`,
-    "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a::wal::WAL>",
+    `0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<${packageAddress}::wal::WAL>`,
     "0x0000000000000000000000000000000000000000000000000000000000000002::object::ID",
   ] satisfies string[];
   const parameterNames = ["staking", "toStake", "nodeId"];
@@ -797,7 +797,7 @@ export function addCommissionToPools(options: AddCommissionToPoolsOptions) {
   const argumentsTypes = [
     `${packageAddress}::staking::Staking`,
     "vector<0x0000000000000000000000000000000000000000000000000000000000000002::object::ID>",
-    "vector<0x0000000000000000000000000000000000000000000000000000000000000002::balance::Balance<0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a::wal::WAL>>",
+    `vector<0x0000000000000000000000000000000000000000000000000000000000000002::balance::Balance<${packageAddress}::wal::WAL>>`,
   ] satisfies string[];
   const parameterNames = ["staking", "nodeIds", "commissions"];
   return (tx: Transaction) =>

--- a/sui/src/generated/walrus/system.ts
+++ b/sui/src/generated/walrus/system.ts
@@ -137,7 +137,7 @@ export function reserveSpace(options: ReserveSpaceOptions) {
     `${packageAddress}::system::System`,
     "u64",
     "u32",
-    "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a::wal::WAL>",
+    `0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<${packageAddress}::wal::WAL>`,
   ] satisfies string[];
   const parameterNames = ["self", "storageAmount", "epochsAhead", "payment"];
   return (tx: Transaction) =>
@@ -181,7 +181,7 @@ export function reserveSpaceForEpochs(options: ReserveSpaceForEpochsOptions) {
     "u64",
     "u32",
     "u32",
-    "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a::wal::WAL>",
+    `0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<${packageAddress}::wal::WAL>`,
   ] satisfies string[];
   const parameterNames = ["self", "storageAmount", "startEpoch", "endEpoch", "payment"];
   return (tx: Transaction) =>
@@ -231,7 +231,7 @@ export function registerBlob(options: RegisterBlobOptions) {
     "u64",
     "u8",
     "bool",
-    "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a::wal::WAL>",
+    `0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<${packageAddress}::wal::WAL>`,
   ] satisfies string[];
   const parameterNames = [
     "self",
@@ -381,7 +381,7 @@ export function extendBlob(options: ExtendBlobOptions) {
     `${packageAddress}::system::System`,
     `${packageAddress}::blob::Blob`,
     "u32",
-    "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a::wal::WAL>",
+    `0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<${packageAddress}::wal::WAL>`,
   ] satisfies string[];
   const parameterNames = ["self", "blob", "extendedEpochs", "payment"];
   return (tx: Transaction) =>
@@ -416,7 +416,7 @@ export function addSubsidy(options: AddSubsidyOptions) {
   const packageAddress = options.package ?? "Walrus";
   const argumentsTypes = [
     `${packageAddress}::system::System`,
-    "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a::wal::WAL>",
+    `0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<${packageAddress}::wal::WAL>`,
     "u32",
   ] satisfies string[];
   const parameterNames = ["system", "subsidy", "epochsAhead"];
@@ -446,7 +446,7 @@ export function addPerEpochSubsidies(options: AddPerEpochSubsidiesOptions) {
   const packageAddress = options.package ?? "Walrus";
   const argumentsTypes = [
     `${packageAddress}::system::System`,
-    "vector<0x0000000000000000000000000000000000000000000000000000000000000002::balance::Balance<0x8270feb7375eee355e64fdb69c50abb6b5f9393a722883c1cf45f8e26048810a::wal::WAL>>",
+    `vector<0x0000000000000000000000000000000000000000000000000000000000000002::balance::Balance<${packageAddress}::wal::WAL>>`,
   ] satisfies string[];
   const parameterNames = ["system", "subsidies"];
   return (tx: Transaction) =>

--- a/sui/src/hooks/queries/usePedersenCounterList.ts
+++ b/sui/src/hooks/queries/usePedersenCounterList.ts
@@ -10,7 +10,10 @@ const PedersenCounterSchema = z.object({
     id: z.string(),
   }),
   commitment: z.object({
-    bytes: z.array(z.number()),
+    type: z.string(),
+    fields: z.object({
+      bytes: z.array(z.number()),
+    }),
   }),
 });
 
@@ -81,7 +84,7 @@ export function usePedersenCounterList() {
 
         counters.push({
           id: objectId,
-          commitmentBytes: parseResult.data.commitment.bytes,
+          commitmentBytes: parseResult.data.commitment.fields.bytes,
           version,
         });
       }

--- a/sui/src/hooks/queries/usePedersenCounterList.ts
+++ b/sui/src/hooks/queries/usePedersenCounterList.ts
@@ -1,0 +1,95 @@
+import { useCurrentAccount, useSuiClient } from "@mysten/dapp-kit";
+import { useQuery } from "@tanstack/react-query";
+import consola from "consola";
+import { z } from "zod";
+import { useNetworkVariable } from "@/networkConfig";
+
+// Zod schema for PedersenCounter validation
+const PedersenCounterSchema = z.object({
+  id: z.object({
+    id: z.string(),
+  }),
+  commitment: z.object({
+    bytes: z.array(z.number()),
+  }),
+});
+
+export type PedersenCounterData = {
+  id: string;
+  commitmentBytes: number[];
+  version: string;
+};
+
+export function usePedersenCounterList() {
+  const account = useCurrentAccount();
+  const suiClient = useSuiClient();
+  const counterPackageId = useNetworkVariable("counterPackageId");
+
+  const counterType = `${counterPackageId}::pedersen_counter::PedersenCounter`;
+
+  return useQuery({
+    queryKey: ["pedersen-counters", account?.address, counterType],
+    queryFn: async (): Promise<PedersenCounterData[]> => {
+      if (!account?.address) return [];
+
+      consola.info("[usePedersenCounterList] Querying with RPC API:", {
+        owner: account.address,
+        type: counterType,
+        packageId: counterPackageId,
+      });
+
+      const result = await suiClient.getOwnedObjects({
+        owner: account.address,
+        filter: {
+          StructType: counterType,
+        },
+        options: {
+          showType: true,
+          showContent: true,
+        },
+      });
+
+      consola.info("[usePedersenCounterList] RPC response:", {
+        count: result.data.length,
+        hasNextPage: result.hasNextPage,
+      });
+
+      const counters: PedersenCounterData[] = [];
+
+      for (const obj of result.data) {
+        if (!obj.data) {
+          consola.warn("[usePedersenCounterList] Object has no data:", obj);
+          continue;
+        }
+
+        const { objectId, version, content } = obj.data;
+
+        if (!content || content.dataType !== "moveObject") {
+          consola.warn("[usePedersenCounterList] Object is not a Move object:", objectId);
+          continue;
+        }
+
+        const parseResult = PedersenCounterSchema.safeParse(content.fields);
+        if (!parseResult.success) {
+          consola.warn("[usePedersenCounterList] Invalid PedersenCounter data:", {
+            objectId,
+            error: parseResult.error.format(),
+            rawData: content.fields,
+          });
+          continue;
+        }
+
+        counters.push({
+          id: objectId,
+          commitmentBytes: parseResult.data.commitment.bytes,
+          version,
+        });
+      }
+
+      consola.info("[usePedersenCounterList] Parsed Pedersen counters:", counters.length);
+
+      return counters;
+    },
+    enabled: !!account?.address && !!counterPackageId,
+  });
+}

--- a/sui/src/hooks/usePedersenCounter.tsx
+++ b/sui/src/hooks/usePedersenCounter.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 import * as pedersenCounter from "@/generated/counter/pedersen_counter";
 import { useNetworkVariable } from "@/networkConfig";
 import { createSerializedCommitment } from "@/utils/pedersen";
+import { addIncrementRecord, saveCounterSecrets } from "@/utils/pedersenStorage";
 
 const buildExplorerLink = (digest: string): string =>
   `https://testnet.suivision.xyz/txblock/${digest}`;
@@ -92,6 +93,9 @@ export function usePedersenCounter() {
         throw new Error("Failed to create Pedersen counter");
       }
 
+      // Save secrets to localStorage for later opening
+      saveCounterSecrets(created.objectId, commitment.value, commitment.blinding);
+
       showTxSuccessToast("Pedersen counter created successfully!", result.digest);
       await queryClient.invalidateQueries({ queryKey: ["pedersen-counters"] });
 
@@ -122,6 +126,9 @@ export function usePedersenCounter() {
       })(tx);
 
       const result = await executeTransaction({ transaction: tx });
+
+      // Save increment secrets to localStorage
+      addIncrementRecord(params.counterId, commitment.value, commitment.blinding, result.digest);
 
       showTxSuccessToast(
         `Counter incremented by ${params.incrementValue} homomorphically!`,

--- a/sui/src/hooks/usePedersenCounter.tsx
+++ b/sui/src/hooks/usePedersenCounter.tsx
@@ -1,0 +1,188 @@
+/**
+ * Pedersen Counter Hook
+ *
+ * Provides operations for Pedersen commitment-based counters:
+ * - Create counter with initial commitment
+ * - Increment counter homomorphically
+ * - Query commitment bytes
+ */
+
+import { useCurrentAccount, useSignAndExecuteTransaction, useSuiClient } from "@mysten/dapp-kit";
+import { type SuiObjectChange } from "@mysten/sui/client";
+import { Transaction } from "@mysten/sui/transactions";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import * as pedersenCounter from "@/generated/counter/pedersen_counter";
+import { useNetworkVariable } from "@/networkConfig";
+import { createSerializedCommitment } from "@/utils/pedersen";
+
+const buildExplorerLink = (digest: string): string =>
+  `https://testnet.suivision.xyz/txblock/${digest}`;
+
+const showTxSuccessToast = (message: string, digest: string) => {
+  toast.success(message, {
+    description: (
+      <a
+        href={buildExplorerLink(digest)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-500 underline"
+      >
+        View transaction on SuiVision
+      </a>
+    ),
+  });
+};
+
+export function usePedersenCounter() {
+  const suiClient = useSuiClient();
+  const { mutateAsync: executeTransaction } = useSignAndExecuteTransaction({
+    execute: async ({ bytes, signature }) => {
+      const executionResult = await suiClient.executeTransactionBlock({
+        transactionBlock: bytes,
+        signature,
+        options: {
+          showRawEffects: true,
+          showObjectChanges: true,
+        },
+        requestType: "WaitForLocalExecution",
+      });
+
+      return suiClient.waitForTransaction({
+        digest: executionResult.digest,
+        options: {
+          showRawEffects: true,
+          showObjectChanges: true,
+        },
+      });
+    },
+  });
+  const queryClient = useQueryClient();
+  const account = useCurrentAccount();
+  const counterPackageId = useNetworkVariable("counterPackageId");
+
+  // ================== Create Pedersen Counter ==================
+  const createPedersenCounter = useMutation({
+    mutationKey: ["counter", "pedersen", "create"],
+    mutationFn: async (params?: { initialValue?: bigint }): Promise<string> => {
+      if (!account?.address) {
+        throw new Error("No account connected");
+      }
+
+      const initialValue = params?.initialValue ?? 0n;
+
+      // Create initial commitment
+      const { commitment, bytes } = createSerializedCommitment(initialValue);
+
+      toast.info("Creating Pedersen commitment", {
+        description: `Value: ${initialValue}, Blinding: ${commitment.blinding.toString(16).slice(0, 8)}...`,
+      });
+
+      const tx = new Transaction();
+      const counter = pedersenCounter._new({
+        package: counterPackageId,
+        arguments: [bytes],
+      })(tx);
+      tx.transferObjects([counter], account.address);
+
+      const result = await executeTransaction({ transaction: tx });
+      const created = result.objectChanges?.find((c: SuiObjectChange) => c.type === "created");
+
+      if (!created || created.type !== "created") {
+        throw new Error("Failed to create Pedersen counter");
+      }
+
+      showTxSuccessToast("Pedersen counter created successfully!", result.digest);
+      await queryClient.invalidateQueries({ queryKey: ["pedersen-counters"] });
+
+      return created.objectId;
+    },
+    onError: (error) => {
+      toast.error("Failed to create Pedersen counter", {
+        description: error.message,
+      });
+    },
+  });
+
+  // ================== Increment Pedersen Counter ==================
+  const incrementPedersenCounter = useMutation({
+    mutationKey: ["counter", "pedersen", "increment"],
+    mutationFn: async (params: { counterId: string; incrementValue: bigint }): Promise<void> => {
+      // Create commitment for the increment value
+      const { commitment, bytes } = createSerializedCommitment(params.incrementValue);
+
+      toast.info("Creating increment commitment", {
+        description: `Increment: ${params.incrementValue}, Blinding: ${commitment.blinding.toString(16).slice(0, 8)}...`,
+      });
+
+      const tx = new Transaction();
+      pedersenCounter.increment({
+        package: counterPackageId,
+        arguments: [tx.object(params.counterId), bytes],
+      })(tx);
+
+      const result = await executeTransaction({ transaction: tx });
+
+      showTxSuccessToast(
+        `Counter incremented by ${params.incrementValue} homomorphically!`,
+        result.digest,
+      );
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["counter", params.counterId] }),
+        queryClient.invalidateQueries({ queryKey: ["pedersen-counters"] }),
+      ]);
+    },
+    onError: (error) => {
+      toast.error("Failed to increment Pedersen counter", {
+        description: error.message,
+      });
+    },
+  });
+
+  // ================== Query Commitment Bytes ==================
+  const queryCommitmentBytes = useMutation({
+    mutationKey: ["counter", "pedersen", "queryBytes"],
+    mutationFn: async (counterId: string): Promise<Uint8Array> => {
+      const obj = await suiClient.getObject({
+        id: counterId,
+        options: { showContent: true },
+      });
+
+      if (!obj.data?.content || obj.data.content.dataType !== "moveObject") {
+        throw new Error("Invalid counter object");
+      }
+
+      const fields = obj.data.content.fields as Record<string, unknown>;
+      const commitment = fields.commitment as Record<string, unknown>;
+
+      // Extract bytes from the Element field
+      if (!commitment || typeof commitment !== "object" || !("bytes" in commitment)) {
+        throw new Error("Invalid commitment structure");
+      }
+
+      const bytes = commitment.bytes as number[];
+      return new Uint8Array(bytes);
+    },
+    onError: (error) => {
+      toast.error("Failed to query commitment bytes", {
+        description: error.message,
+      });
+    },
+  });
+
+  // ================== Unified API ==================
+  return {
+    create: createPedersenCounter.mutateAsync,
+    increment: incrementPedersenCounter.mutateAsync,
+    queryBytes: queryCommitmentBytes.mutateAsync,
+    isPending: {
+      create: createPedersenCounter.isPending,
+      increment: incrementPedersenCounter.isPending,
+      queryBytes: queryCommitmentBytes.isPending,
+    },
+  };
+}
+
+// Type exports
+export type PedersenCounterHookResult = ReturnType<typeof usePedersenCounter>;

--- a/sui/src/hooks/usePedersenCounter.tsx
+++ b/sui/src/hooks/usePedersenCounter.tsx
@@ -84,6 +84,7 @@ export function usePedersenCounter() {
         package: counterPackageId,
         arguments: [bytes],
       })(tx);
+
       tx.transferObjects([counter], account.address);
 
       const result = await executeTransaction({ transaction: tx });

--- a/sui/src/hooks/usePedersenOpening.ts
+++ b/sui/src/hooks/usePedersenOpening.ts
@@ -1,0 +1,92 @@
+/**
+ * Pedersen Opening Hook
+ *
+ * Provides functionality to "open" (reveal) Pedersen commitments
+ * by retrieving stored secrets and verifying against on-chain data
+ */
+
+import consola from "consola";
+import { ResultAsync } from "neverthrow";
+import { useState } from "react";
+import { openCommitment } from "@/utils/pedersen";
+import { calculateTotals, hasSecrets } from "@/utils/pedersenStorage";
+
+export interface OpeningResult {
+  success: boolean;
+  value?: bigint;
+  error?: string;
+}
+
+export function usePedersenOpening() {
+  const [isOpening, setIsOpening] = useState(false);
+
+  /**
+   * Check if we have secrets stored for a counter
+   */
+  const checkHasSecrets = (counterId: string): boolean => {
+    return hasSecrets(counterId);
+  };
+
+  /**
+   * Attempt to open a commitment
+   * @param counterId - The counter ID
+   * @param onchainCommitmentBytes - The commitment bytes from on-chain (number[])
+   * @returns Opening result with value if successful
+   */
+  const open = async (
+    counterId: string,
+    onchainCommitmentBytes: number[],
+  ): Promise<OpeningResult> => {
+    setIsOpening(true);
+
+    const result = await ResultAsync.fromPromise(
+      Promise.resolve().then(() => {
+        // Get stored secrets
+        const totals = calculateTotals(counterId);
+
+        if (!totals) {
+          throw new Error(
+            "No secrets found for this counter. Secrets may have been cleared or this counter was created on another device/browser.",
+          );
+        }
+
+        const { totalValue, totalBlinding } = totals;
+
+        // Verify the commitment
+        const isValid = openCommitment(totalValue, totalBlinding, onchainCommitmentBytes);
+
+        if (!isValid) {
+          throw new Error(
+            "Commitment verification failed. The stored secrets do not match the on-chain commitment.",
+          );
+        }
+
+        return totalValue;
+      }),
+      (error) => new Error(error instanceof Error ? error.message : "Unknown error during opening"),
+    );
+
+    setIsOpening(false);
+
+    if (result.isErr()) {
+      consola.error("[usePedersenOpening] Error during opening:", result.error);
+      return {
+        success: false,
+        error: result.error.message,
+      };
+    }
+
+    return {
+      success: true,
+      value: result.value,
+    };
+  };
+
+  return {
+    open,
+    checkHasSecrets,
+    isOpening,
+  };
+}
+
+export type PedersenOpeningHook = ReturnType<typeof usePedersenOpening>;

--- a/sui/src/networkConfig.ts
+++ b/sui/src/networkConfig.ts
@@ -5,7 +5,7 @@ const { networkConfig, useNetworkVariable, useNetworkVariables } = createNetwork
   testnet: {
     url: getFullnodeUrl("testnet"),
     variables: {
-      counterPackageId: "0x6aa35f5f737f106c867d45cb02e39c61cbd5359088a929d161363bd34f62fd8a",
+      counterPackageId: "0xce89666455299b6048aca6bb04a572ac3bb45addd97d45aff1c1d3576ea5cda8",
       sealPackageId: "0x73bba649fe918ef501e2fb6ab82e83450a4c286f52cf3399e678e6da257f0c50",
       walrusPackageId: "0xd84704c17fc870b8764832c535aa6b11f21a95cd6f5bb38a9b07d2cf42220c66",
       suiPackageId: "0x2",

--- a/sui/src/networkConfig.ts
+++ b/sui/src/networkConfig.ts
@@ -5,7 +5,7 @@ const { networkConfig, useNetworkVariable, useNetworkVariables } = createNetwork
   testnet: {
     url: getFullnodeUrl("testnet"),
     variables: {
-      counterPackageId: "0x04bb1e13575545cd37a837367779cd4df26bdd566bf181b4ac4c358a8fac68d9",
+      counterPackageId: "0x6aa35f5f737f106c867d45cb02e39c61cbd5359088a929d161363bd34f62fd8a",
       sealPackageId: "0x73bba649fe918ef501e2fb6ab82e83450a4c286f52cf3399e678e6da257f0c50",
       walrusPackageId: "0xd84704c17fc870b8764832c535aa6b11f21a95cd6f5bb38a9b07d2cf42220c66",
       suiPackageId: "0x2",

--- a/sui/src/utils/pedersen.ts
+++ b/sui/src/utils/pedersen.ts
@@ -12,6 +12,7 @@
 
 import { bls12_381 } from "@noble/curves/bls12-381.js";
 import { randomBytes } from "@noble/hashes/utils.js";
+import consola from "consola";
 import { Result } from "neverthrow";
 
 // Use the G1 point class directly from bls12_381
@@ -158,4 +159,52 @@ export function verifyCommitment(commitment: PedersenCommitment): boolean {
   }
 
   return true;
+}
+
+/**
+ * Open (reveal) a Pedersen commitment by verifying it matches the claimed value and blinding
+ *
+ * @param value - The claimed committed value
+ * @param blinding - The blinding factor used during commitment
+ * @param commitmentBytes - The 48-byte commitment from on-chain (as number array)
+ * @returns true if the commitment opens correctly, false otherwise
+ */
+export function openCommitment(
+  value: bigint,
+  blinding: bigint,
+  commitmentBytes: number[],
+): boolean {
+  const result = Result.fromThrowable(
+    () => {
+      // Recreate the commitment from the claimed value and blinding
+      const recreated = createCommitment(value, blinding);
+
+      // Serialize it to compare with on-chain
+      const recreatedBytes = serializeCommitment(recreated);
+
+      // Convert on-chain bytes to Uint8Array
+      const onchainBytes = new Uint8Array(commitmentBytes);
+
+      // Compare byte-by-byte
+      if (recreatedBytes.length !== onchainBytes.length) {
+        throw new Error("Commitment length mismatch");
+      }
+
+      for (let i = 0; i < recreatedBytes.length; i++) {
+        if (recreatedBytes[i] !== onchainBytes[i]) {
+          throw new Error("Commitment bytes mismatch");
+        }
+      }
+
+      return true;
+    },
+    (error) => new Error(error instanceof Error ? error.message : String(error)),
+  )();
+
+  if (result.isErr()) {
+    consola.error("[pedersen] Failed to open commitment:", result.error);
+    return false;
+  }
+
+  return result.value;
 }

--- a/sui/src/utils/pedersen.ts
+++ b/sui/src/utils/pedersen.ts
@@ -12,6 +12,7 @@
 
 import { bls12_381 } from "@noble/curves/bls12-381.js";
 import { randomBytes } from "@noble/hashes/utils.js";
+import { Result } from "neverthrow";
 
 // Use the G1 point class directly from bls12_381
 const G1Point = bls12_381.G1.Point;
@@ -141,18 +142,20 @@ export function createSerializedCommitment(value: bigint, blinding?: bigint) {
  * @returns true if valid
  */
 export function verifyCommitment(commitment: PedersenCommitment): boolean {
-  // eslint-disable-next-line no-restricted-syntax
-  try {
-    // Check if point is on curve
-    commitment.point.assertValidity();
+  // Check if point is on curve using neverthrow
+  const validityResult = Result.fromThrowable(
+    () => commitment.point.assertValidity(),
+    () => new Error("Point is not on curve"),
+  )();
 
-    // Check if point is not the identity element
-    if (commitment.point.equals(G1Point.ZERO)) {
-      return false;
-    }
-
-    return true;
-  } catch {
+  if (validityResult.isErr()) {
     return false;
   }
+
+  // Check if point is not the identity element
+  if (commitment.point.equals(G1Point.ZERO)) {
+    return false;
+  }
+
+  return true;
 }

--- a/sui/src/utils/pedersen.ts
+++ b/sui/src/utils/pedersen.ts
@@ -49,8 +49,9 @@ export function createCommitment(value: bigint, blinding?: bigint): PedersenComm
   const normalizedBlinding = r % frOrder;
 
   // C = value * G + r * H
-  const valuePoint = G.multiply(normalizedValue);
-  const blindingPoint = H.multiply(normalizedBlinding);
+  // Handle zero case: multiply() doesn't accept 0, so use ZERO point
+  const valuePoint = normalizedValue === 0n ? G1Point.ZERO : G.multiply(normalizedValue);
+  const blindingPoint = normalizedBlinding === 0n ? G1Point.ZERO : H.multiply(normalizedBlinding);
   const point = valuePoint.add(blindingPoint);
 
   return {

--- a/sui/src/utils/pedersen.ts
+++ b/sui/src/utils/pedersen.ts
@@ -1,0 +1,157 @@
+/**
+ * Pedersen Commitment utilities for BLS12-381 G1 curve
+ *
+ * Commitment: C = value * G + blinding * H
+ * where G and H are generators on the BLS12-381 G1 curve
+ *
+ * This module provides utilities for:
+ * - Generating commitments to values with random blinding factors
+ * - Homomorphic addition of commitments
+ * - Serialization to/from 48-byte compressed format
+ */
+
+import { bls12_381 } from "@noble/curves/bls12-381.js";
+import { randomBytes } from "@noble/hashes/utils.js";
+
+// Use the G1 point class directly from bls12_381
+const G1Point = bls12_381.G1.Point;
+
+// Generator G (BLS12-381 G1 base point)
+const G = G1Point.BASE;
+
+// Generator H (derived from G using hash-to-curve for independence)
+// In production, this should be a standardized nothing-up-my-sleeve point
+// For demo purposes, we use a simple derivation with a small scalar
+// The scalar must be within the field order (Fr)
+const H = G.multiply(BigInt("12345678901234567890"));
+
+export interface PedersenCommitment {
+  /** The commitment point C = value * G + blinding * H */
+  point: typeof G1Point.ZERO;
+  /** The committed value */
+  value: bigint;
+  /** The blinding factor (secret) */
+  blinding: bigint;
+}
+
+/**
+ * Create a Pedersen commitment to a value
+ * @param value - The value to commit to (will be used as scalar)
+ * @param blinding - Optional blinding factor (random if not provided)
+ * @returns PedersenCommitment object containing point, value, and blinding
+ */
+export function createCommitment(value: bigint, blinding?: bigint): PedersenCommitment {
+  const r = blinding ?? generateBlindingFactor();
+
+  // Ensure values are within the field order
+  const frOrder = bls12_381.fields.Fr.ORDER;
+  const normalizedValue = value % frOrder;
+  const normalizedBlinding = r % frOrder;
+
+  // C = value * G + r * H
+  const valuePoint = G.multiply(normalizedValue);
+  const blindingPoint = H.multiply(normalizedBlinding);
+  const point = valuePoint.add(blindingPoint);
+
+  return {
+    point,
+    value: normalizedValue,
+    blinding: normalizedBlinding,
+  };
+}
+
+/**
+ * Generate a random blinding factor
+ * @returns Random 32-byte scalar as bigint
+ */
+export function generateBlindingFactor(): bigint {
+  const bytes = randomBytes(32);
+  return BigInt(`0x${Buffer.from(bytes).toString("hex")}`) % bls12_381.fields.Fr.ORDER;
+}
+
+/**
+ * Add two commitments homomorphically
+ * C_result = C1 + C2 = (v1 + v2) * G + (r1 + r2) * H
+ *
+ * @param c1 - First commitment
+ * @param c2 - Second commitment
+ * @returns New commitment representing the sum
+ */
+export function addCommitments(c1: PedersenCommitment, c2: PedersenCommitment): PedersenCommitment {
+  return {
+    point: c1.point.add(c2.point),
+    value: c1.value + c2.value,
+    blinding: c1.blinding + c2.blinding,
+  };
+}
+
+/**
+ * Serialize a commitment point to 48-byte compressed format (for Sui)
+ * @param commitment - The commitment to serialize
+ * @returns Uint8Array of 48 bytes (compressed G1 point)
+ */
+export function serializeCommitment(commitment: PedersenCommitment): Uint8Array {
+  return commitment.point.toBytes(true); // true = compressed format (48 bytes)
+}
+
+/**
+ * Deserialize a commitment point from 48-byte compressed format
+ * @param bytes - 48-byte compressed G1 point
+ * @returns G1 Point
+ */
+export function deserializePoint(bytes: Uint8Array): typeof G1Point.ZERO {
+  if (bytes.length !== 48) {
+    throw new Error(`Invalid commitment bytes length: expected 48, got ${bytes.length}`);
+  }
+  return G1Point.fromBytes(bytes);
+}
+
+/**
+ * Convert Uint8Array to number array for Sui transaction arguments
+ * @param bytes - Uint8Array to convert
+ * @returns Array of numbers
+ */
+export function toNumberArray(bytes: Uint8Array): number[] {
+  return Array.from(bytes);
+}
+
+/**
+ * Helper: Create a commitment and return serialized bytes as number array
+ * This is the format expected by Sui Move functions
+ *
+ * @param value - The value to commit to
+ * @param blinding - Optional blinding factor
+ * @returns Object containing commitment and serialized bytes as number array
+ */
+export function createSerializedCommitment(value: bigint, blinding?: bigint) {
+  const commitment = createCommitment(value, blinding);
+  const bytes = serializeCommitment(commitment);
+  const numberArray = toNumberArray(bytes);
+
+  return {
+    commitment,
+    bytes: numberArray,
+  };
+}
+
+/**
+ * Verify that a commitment is valid (point is on curve and not identity)
+ * @param commitment - The commitment to verify
+ * @returns true if valid
+ */
+export function verifyCommitment(commitment: PedersenCommitment): boolean {
+  // eslint-disable-next-line no-restricted-syntax
+  try {
+    // Check if point is on curve
+    commitment.point.assertValidity();
+
+    // Check if point is not the identity element
+    if (commitment.point.equals(G1Point.ZERO)) {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/sui/src/utils/pedersenStorage.ts
+++ b/sui/src/utils/pedersenStorage.ts
@@ -1,0 +1,229 @@
+/**
+ * Pedersen Counter Secrets Storage
+ *
+ * Manages localStorage for Pedersen commitment secrets (values and blinding factors).
+ * This allows users to "open" (reveal) their committed values later.
+ *
+ * SECURITY WARNING:
+ * - Data is stored in browser localStorage in PLAINTEXT
+ * - Secrets are NOT encrypted
+ * - If localStorage is cleared, secrets are PERMANENTLY LOST
+ * - Secrets are device/browser-specific (not synced across devices)
+ */
+
+import consola from "consola";
+import { Result } from "neverthrow";
+import { z } from "zod";
+
+const STORAGE_KEY = "pedersen_secrets";
+
+// Zod schemas for validation
+const IncrementRecordSchema = z.object({
+  value: z.string(), // BigInt as string
+  blinding: z.string(), // BigInt as string
+  timestamp: z.number(),
+  txDigest: z.string().optional(),
+});
+
+const CounterSecretsSchema = z.object({
+  initialValue: z.string(), // BigInt as string
+  initialBlinding: z.string(), // BigInt as string
+  increments: z.array(IncrementRecordSchema),
+  createdAt: z.number(),
+});
+
+const StorageSchema = z.record(z.string(), CounterSecretsSchema);
+
+export type IncrementRecord = z.infer<typeof IncrementRecordSchema>;
+export type CounterSecrets = z.infer<typeof CounterSecretsSchema>;
+
+/**
+ * Get all stored secrets from localStorage
+ */
+function getStorage(): Record<string, CounterSecrets> {
+  const result = Result.fromThrowable(
+    () => {
+      const data = localStorage.getItem(STORAGE_KEY);
+      if (!data) return {};
+
+      const parsed = JSON.parse(data);
+      const validated = StorageSchema.safeParse(parsed);
+
+      if (!validated.success) {
+        consola.warn("[pedersenStorage] Invalid storage data, resetting:", validated.error);
+        return {};
+      }
+
+      return validated.data;
+    },
+    (error) => new Error(error instanceof Error ? error.message : String(error)),
+  )();
+
+  if (result.isErr()) {
+    consola.error("[pedersenStorage] Failed to read storage:", result.error);
+    return {};
+  }
+
+  return result.value;
+}
+
+/**
+ * Save storage to localStorage
+ */
+function setStorage(data: Record<string, CounterSecrets>): void {
+  const result = Result.fromThrowable(
+    () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    },
+    (error) => new Error(error instanceof Error ? error.message : String(error)),
+  )();
+
+  if (result.isErr()) {
+    consola.error("[pedersenStorage] Failed to write storage:", result.error);
+    throw new Error("Failed to save secrets to localStorage");
+  }
+}
+
+/**
+ * Save initial counter secrets (at creation time)
+ */
+export function saveCounterSecrets(
+  counterId: string,
+  initialValue: bigint,
+  initialBlinding: bigint,
+): void {
+  const storage = getStorage();
+
+  storage[counterId] = {
+    initialValue: initialValue.toString(),
+    initialBlinding: initialBlinding.toString(),
+    increments: [],
+    createdAt: Date.now(),
+  };
+
+  setStorage(storage);
+  consola.info(`[pedersenStorage] Saved secrets for counter ${counterId}`);
+}
+
+/**
+ * Add an increment record to existing counter
+ */
+export function addIncrementRecord(
+  counterId: string,
+  value: bigint,
+  blinding: bigint,
+  txDigest?: string,
+): void {
+  const storage = getStorage();
+
+  if (!storage[counterId]) {
+    consola.warn(`[pedersenStorage] Counter ${counterId} not found, cannot add increment`);
+    return;
+  }
+
+  storage[counterId].increments.push({
+    value: value.toString(),
+    blinding: blinding.toString(),
+    timestamp: Date.now(),
+    txDigest,
+  });
+
+  setStorage(storage);
+  consola.info(`[pedersenStorage] Added increment to counter ${counterId}`);
+}
+
+/**
+ * Get secrets for a specific counter
+ */
+export function getCounterSecrets(counterId: string): CounterSecrets | null {
+  const storage = getStorage();
+  return storage[counterId] || null;
+}
+
+/**
+ * Check if secrets exist for a counter
+ */
+export function hasSecrets(counterId: string): boolean {
+  const storage = getStorage();
+  return !!storage[counterId];
+}
+
+/**
+ * Calculate total value and blinding from stored secrets
+ */
+export function calculateTotals(counterId: string): {
+  totalValue: bigint;
+  totalBlinding: bigint;
+} | null {
+  const secrets = getCounterSecrets(counterId);
+  if (!secrets) return null;
+
+  let totalValue = BigInt(secrets.initialValue);
+  let totalBlinding = BigInt(secrets.initialBlinding);
+
+  for (const inc of secrets.increments) {
+    totalValue += BigInt(inc.value);
+    totalBlinding += BigInt(inc.blinding);
+  }
+
+  return { totalValue, totalBlinding };
+}
+
+/**
+ * Delete secrets for a specific counter
+ */
+export function deleteCounterSecrets(counterId: string): void {
+  const storage = getStorage();
+  delete storage[counterId];
+  setStorage(storage);
+  consola.info(`[pedersenStorage] Deleted secrets for counter ${counterId}`);
+}
+
+/**
+ * Export all secrets as JSON (for backup)
+ */
+export function exportAllSecrets(): string {
+  const storage = getStorage();
+  return JSON.stringify(storage, null, 2);
+}
+
+/**
+ * Import secrets from JSON (restore from backup)
+ */
+export function importSecrets(jsonData: string): void {
+  const result = Result.fromThrowable(
+    () => {
+      const parsed = JSON.parse(jsonData);
+      const validated = StorageSchema.safeParse(parsed);
+
+      if (!validated.success) {
+        throw new Error("Invalid secrets format");
+      }
+
+      setStorage(validated.data);
+      consola.info("[pedersenStorage] Imported secrets successfully");
+    },
+    (error) => new Error(error instanceof Error ? error.message : String(error)),
+  )();
+
+  if (result.isErr()) {
+    consola.error("[pedersenStorage] Failed to import secrets:", result.error);
+    throw new Error("Failed to import secrets");
+  }
+}
+
+/**
+ * Clear all stored secrets (USE WITH CAUTION)
+ */
+export function clearAllSecrets(): void {
+  localStorage.removeItem(STORAGE_KEY);
+  consola.warn("[pedersenStorage] All secrets cleared");
+}
+
+/**
+ * Get list of all counter IDs with stored secrets
+ */
+export function getAllCounterIds(): string[] {
+  const storage = getStorage();
+  return Object.keys(storage);
+}


### PR DESCRIPTION
Introduce a Pedersen commitment counter with functionality for creation, listing, and management. Add tests for commitment operations, handle zero values in commitment creation, and update network configurations for testnet. Enhance the user interface with new links and components for the Pedersen counter.